### PR TITLE
Add cas proxy variable

### DIFF
--- a/eirb-connect/app/conf.py
+++ b/eirb-connect/app/conf.py
@@ -14,7 +14,9 @@ load_dotenv(dotenv_path=dotenv_path)
 
 APP_URL = os.getenv('APP_URL', "http://127.0.0.1:8080")
 CAS_SERVICE_URL = os.getenv(
-    'CAS_SERVICE_URL', "https://cas.serveur-bde.eirb.fr/login")
+    'CAS_SERVICE_URL', "https://cas.bordeaux-inp.fr/")
+
+CAS_PROXY = os.getenv('CAS_PROXY', "")
 
 
 host = os.getenv('MONGO_URI', 'localhost:27017')


### PR DESCRIPTION
Added a CAS_PROXY .env variable, default is "", if not set, the app uses the url CAS_SERVICE_URL (which should be https://cas.bordeaux-inp.fr).

That reduces the number of redirections once deployed in production.

TODO: documentation in the file README.md

PS: I tested the code on eirb.fr (I didn't use external service, just direct login to roulade.eirb.fr), the redirections worked properly