### PR TITLE
fix: eirbot's telegram links

### DIFF
--- a/assos.eirb.fr/static/assos.json
+++ b/assos.eirb.fr/static/assos.json
@@ -181,7 +181,7 @@
     },
     {
         "name": "Eirbot",
-        "links": ["https://t.me/+dA0AiKYFDCgwYjM0"],
+        "links": ["https://t.me/AssoEirbot", "https://t.me/+TMTM0ikWbOk4Y2I0"],
         "logo": "logos/x256/eirbot.png"
     },
     {


### PR DESCRIPTION
Change _Potites Loutres_ channel into the new _Pitites Loutres_ one. Also added the official Eirbot's telegram channel