### PR TITLE
feat: petits paniers campus in assos.eirb.fr

### DIFF
--- a/assos.eirb.fr/static/assos.json
+++ b/assos.eirb.fr/static/assos.json
@@ -274,6 +274,11 @@
         "logo": "logos/x256/paleirb.png"
     },
     {
+        "name": "Petits Paniers Campus (PPC)",
+        "links": ["https://t.me/ppcenseirb"],
+        "logo": "logos/x256/ppc.png"
+    },
+    {
         "name": "Pet'eirb",
         "links": ["https://t.me/peteirb"],
         "logo": "logos/x256/peteirb.png"


### PR DESCRIPTION
Les PPC sont bien plus qu'un club et qu'une asso : ils sont une nation. Ils doivent donc officiellement exister en paraissant sur assos.eirb.fr

PPC Army !!!!